### PR TITLE
[Fix] Fixes links to Jason's Hasura Example

### DIFF
--- a/src/examples/creating-an-api-with-hasura.md
+++ b/src/examples/creating-an-api-with-hasura.md
@@ -1,6 +1,6 @@
 ---
 title: Creating an API with Hasura
-code: learnwithjason/learnwithjason.dev/blob/main/functions/schedule.js
+code:  learnwithjason/learnwithjason.dev/blob/f429560843388fab8c932a62df245071a4411bac/site/netlify/functions/api-schedule.ts
 tags: 
   - hasura
   - database
@@ -15,4 +15,4 @@ tags:
 Create a custom REST API endpoint backed by PostgreSQL using Hasura, GraphQL, and a serverless function.
 
 - As used on [Learn With Jason](https://github.com/learnwithjason/learnwithjason.dev)
-- [Direct link to function](https://github.com/learnwithjason/learnwithjason.dev/blob/main/functions/schedule.js)
+- [Direct link to function](learnwithjason/learnwithjason.dev/blob/f429560843388fab8c932a62df245071a4411bac/site/netlify/functions/api-schedule.ts)


### PR DESCRIPTION
This PR addresses this issue on another repo, but it relates to this repo's codebase:

learnwithjason/learnwithjason.dev#50

It fixes links in this example: https://functions.netlify.com/example/creating-an-api-with-hasura/